### PR TITLE
Version 2.1.6!  New custom serializer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,9 @@ nicknames for these methods, respectively:
 `ballots` should be an iterable containing individual ballots.
 A ballot is a `dict` mapping the candidate to that ballot's
 score for that candidate.  The candidate can be any hashable
-Python value; the score must be an `int`.
+Python value; the score must be an `int`.  (Note that
+tiebreakers may add additional restrictions to the candidate
+and score values.)
 
 `maximum_score` specifies the maximum score allowed for
 any vote on any ballot.
@@ -358,20 +360,28 @@ in `candidates=None`.
 
 #### `hashed_ballots_tiebreaker`
 
-The preferred tiebreaker for **starvote** is
-`hashed_ballots_tiebreaker`.
+**starvote**'s preferred--and default--tiebreaker
+is `hashed_ballots_tiebreaker`.
 This is a class; you should instantiate it
 and pass in the instance as the `tiebreaker`
 argument when you run the election.
 
 `hashed_ballots_tiebreaker` is the preferred
-tiebreaker for **starvote** because it is
+tiebreaker for **starvote** because it's
 
 * impossible to usefully control externally,
 * impossible to predict, yet
 * completely deterministic.
 
-Here's how it works.  At initialization time,
+Note that the default serializer used by
+`hashed_ballots_tiebreaker` requires all candidates
+to be `str` objects, and all votes have to be `int`
+objects.  If you don't change any defaults, you must
+restrict yourself to these types (which you probably
+were already doing anyway).
+
+Here's `hashed_ballots_tiebreaker`
+it works.  At initialization time,
 this tiebreaker:
 
 * computes a list of all candidates, then

--- a/README.md
+++ b/README.md
@@ -261,9 +261,12 @@ or an instance of a tiebreaker class.  See the
 tiebreakers.
 
 `verbosity` specifies how much output you want.
-The current supported values are `0` (no output)
-and `1` (output); values higher than `1` are
-currently equivalent to `1`.
+In most contexts, the supported values are `0`
+(no output) and `1` (output); some contexts
+support higher verbosity values to mean
+"print more information", e.g.
+`hashed_ballots_tiebreaker` produces incremental
+output for verbosity levels `2` and `3`.
 
 `print` lets you specify your own printing function.
 By default `election` will use `builtins.print`;
@@ -376,8 +379,8 @@ this tiebreaker:
 * sorts each ballot, then
 * sorts a list of all the sorted ballots, then
 * converts this sorted list of sorted ballots
-  into a binary string (using `marshal.dumps`
-  by default).
+  into a binary string (using a custom binary
+  serializer by default).
 
 Then, when it's asked to break a tie, it
 
@@ -1086,9 +1089,11 @@ or otherwise freely redistributable.
 
 **2.1.6** - *2024/12/12*
 
-* Bugfix: the `hashed_ballots_tiebreaker` assumed
-  that `marshal.dumps` produced an identical bytes
-  string given identical inputs.  This is not true!
+* Bugfix: previously, `hashed_ballots_tiebreaker` used
+  `marshal.dumps` as its binary serializer, because I assumed
+  given identical objects it would always produce
+  an identical bytes string.  This is not true!
+  (And thanks to Petr Viktorin for pointing it out!)
   We also apparently can't rely on `pickle.dumps`
   to be deterministic.  So, **starvote** now has
   its own bespoke--and completely deterministic--simple

--- a/README.md
+++ b/README.md
@@ -1087,23 +1087,29 @@ or otherwise freely redistributable.
 
 ## Changelog
 
-**2.1.6** - *2024/12/12*
+**2.1.6** - *2024/12/13*
 
 * Bugfix: previously, `hashed_ballots_tiebreaker` used
-  `marshal.dumps` as its binary serializer, because I assumed
-  given identical objects it would always produce
-  an identical bytes string.  This is not true!
+  `marshal.dumps` as its binary serializer, because I
+  assumed given identical objects it would always
+  produce an identical bytes string.  This is not true!
   (And thanks to Petr Viktorin for pointing it out!)
   We also apparently can't rely on `pickle.dumps`
-  to be deterministic.  So, **starvote** now has
-  its own bespoke--and completely deterministic--simple
-  binary serializer, called `starvote_custom_serializer`.
-  It's tailor-made for the needs of **starvote** and
-  isn't useful for anybody else.  But it does guarantee
-  that `hashed_ballots_tiebreaker` will now produce
+  to be deterministic, for similar reasons.
+
+  So, **starvote** now has its own bespoke--and
+  completely deterministic--simple binary serializer,
+  called `starvote_custom_serializer`.  It's tailor-made
+  for the needs of **starvote** and isn't useful for
+  anybody else.  But it does guarantee that
+  `hashed_ballots_tiebreaker` will now produce
   identical results across all supported Python
   versions, across all architectures, regardless of
   optimization level.
+
+  (There's also a matching deserializer, naturally called
+  `starvote_custom_deserializer`.  You shouldn't need
+  to use it either.)
 
 **2.1.5** - *2024/11/22*
 

--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,22 @@ or otherwise freely redistributable.
 
 ## Changelog
 
+**2.1.6** - *2024/12/12*
+
+* Bugfix: the `hashed_ballots_tiebreaker` assumed
+  that `marshal.dumps` produced an identical bytes
+  string given identical inputs.  This is not true!
+  We also apparently can't rely on `pickle.dumps`
+  to be deterministic.  So, **starvote** now has
+  its own bespoke--and completely deterministic--simple
+  binary serializer, called `starvote_custom_serializer`.
+  It's tailor-made for the needs of **starvote** and
+  isn't useful for anybody else.  But it does guarantee
+  that `hashed_ballots_tiebreaker` will now produce
+  identical results across all supported Python
+  versions, across all architectures, regardless of
+  optimization level.
+
 **2.1.5** - *2024/11/22*
 
 * New tiebreaker: The `hashed_ballots_tiebreaker`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     ]
 dynamic = [
     'version',

--- a/starvote/__init__.py
+++ b/starvote/__init__.py
@@ -574,6 +574,7 @@ class _reader(io.BytesIO):
         got = self()
         if got != c:
             raise ValueError(f"expected {c!r}, got {got!r}")
+        return True
 
 
 def starvote_custom_deserializer(b):

--- a/starvote/__init__.py
+++ b/starvote/__init__.py
@@ -500,12 +500,8 @@ def starvote_custom_serializer(o):
     else:
         ballots = o
 
-        assert isinstance(ballots, list)
-        assert isinstance(ballots[0], list)
-        assert isinstance(ballots[0][0], tuple)
-        assert len(ballots[0][0]) == 2
-        assert isinstance(ballots[0][0][0], str)
-        assert isinstance(ballots[0][0][1], int)
+        if not isinstance(ballots, list):
+            raise TypeError("ballots must be a list")
 
         write(_serialized_ballot_marker)
         write(_unit_separator)
@@ -516,7 +512,18 @@ def starvote_custom_serializer(o):
             if ballot_number:
                 write(_group_separator)
 
-            for entry_number, (candidate, vote) in enumerate(ballot):
+            if not isinstance(ballot, list):
+                raise TypeError(f"each ballot in ballots must be a list, ballots[{ballot_number}] is type {type(ballot)}")
+
+            for entry_number, t in enumerate(ballot):
+                if not (isinstance(t, tuple) and (len(t) == 2)):
+                    raise TypeError(f"each vote in each ballot in ballots must be a tuple of length 2, ballots[{ballot_number}][{entry_number}] is type {type(t)}")
+                candidate, vote = t
+                if not isinstance(candidate, str):
+                    raise TypeError(f"candidate must be str, but {candidate!r} is {type(candidate)}")
+                if not isinstance(vote, int):
+                    raise TypeError(f"vote must be int, but {vote!r} is {type(vote)}")
+
                 if entry_number:
                     write(_record_separator)
 

--- a/test_elections/test_election_hashed_ballot_tiebreaker.txt
+++ b/test_elections/test_election_hashed_ballot_tiebreaker.txt
@@ -6,8 +6,8 @@
 [Bloc STAR: Initializing Hashed Ballots tiebreaker]
  8 candidates
  Counter initialized to 1
- Serialized sorted ballots = (1233 bytes)
- Hexdigest of serialized sorted ballots = 419128f36f760b5744f38e421e1154de0df636f9da558e5730827b5d0ce29da6d2f5cc9872929de9575c197d144b94719920144c2d06f64e4f2eeba0bf2ea0d5
+ Serialized sorted ballots = (780 bytes)
+ Hexdigest of serialized sorted ballots = 43cf03fbebcd47246931fdeccf703c78217ce4c0d3f4de5b7096fdb072dedb18025cf76a620a4f569bc3e8cb940be5b6667470ac0a7ec4bef781b562131efac5
 
 [Bloc STAR: Round 1: Scoring Round]
  The two highest-scoring candidates advance to the next round.
@@ -51,14 +51,14 @@
  Counter is now 1
  3 shuffles
  Permuted list of candidates:
-   Hank
-   Amy
    Brian
+   Amy
    Fred
    Emily
-   Geraldine
    David
+   Geraldine
    Chuck
+   Hank
  Choosing the earliest two of these candidates from the permuted list:
    Amy
    Brian
@@ -68,25 +68,25 @@
    Fred
    Geraldine
    Hank
- Selected winners: Hank and Amy
+ Selected winners: Brian and Amy
 
 [Bloc STAR: Round 1: Automatic Runoff Round]
  The candidate preferred in the most head-to-head matchups wins.
    Amy           --  0 -- Tied for first place
-   Hank          --  0 -- Tied for first place
+   Brian         --  0 -- Tied for first place
    No Preference -- 12
  There's a two-way tie for first.
 
 [Bloc STAR: Round 1: Automatic Runoff Round: First tiebreaker]
  The highest-scoring candidate wins.
-   Amy  -- 36 -- Tied for first place
-   Hank -- 36 -- Tied for first place
+   Amy   -- 36 -- Tied for first place
+   Brian -- 36 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 1: Automatic Runoff Round: Second tiebreaker]
  The candidate with the most votes of score 5 wins.
-   Amy  -- 0 -- Tied for first place
-   Hank -- 0 -- Tied for first place
+   Amy   -- 0 -- Tied for first place
+   Brian -- 0 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 1: Automatic Runoff Round: Hashed Ballots tiebreaker]
@@ -94,51 +94,51 @@
  Counter is now 2
  3 shuffles
  Permuted list of candidates:
-   Hank
-   Emily
    Fred
+   Emily
    Brian
-   Geraldine
+   Hank
    David
-   Chuck
    Amy
+   Geraldine
+   Chuck
  Choosing the earliest of these candidates from the permuted list:
    Amy
-   Hank
- Selected winner: Hank
+   Brian
+ Selected winner: Brian
 
 [Bloc STAR: Round 2: Scoring Round]
  The two highest-scoring candidates advance to the next round.
    Amy       -- 36 (average 3) -- Tied for first place
-   Brian     -- 36 (average 3) -- Tied for first place
    Chuck     -- 36 (average 3) -- Tied for first place
    David     -- 36 (average 3) -- Tied for first place
    Emily     -- 36 (average 3) -- Tied for first place
    Fred      -- 36 (average 3) -- Tied for first place
    Geraldine -- 36 (average 3) -- Tied for first place
+   Hank      -- 36 (average 3) -- Tied for first place
  There's a seven-way tie for first.
 
 [Bloc STAR: Round 2: Scoring Round: First tiebreaker]
  The two candidates preferred in the most head-to-head matchups advance.
    Amy           --  0 -- Tied for first place
-   Brian         --  0 -- Tied for first place
    Chuck         --  0 -- Tied for first place
    David         --  0 -- Tied for first place
    Emily         --  0 -- Tied for first place
    Fred          --  0 -- Tied for first place
    Geraldine     --  0 -- Tied for first place
+   Hank          --  0 -- Tied for first place
    No Preference -- 12
  There's still a seven-way tie for first.
 
 [Bloc STAR: Round 2: Scoring Round: Second tiebreaker]
  The two candidates with the most votes of score 5 advance.
    Amy       -- 0 -- Tied for first place
-   Brian     -- 0 -- Tied for first place
    Chuck     -- 0 -- Tied for first place
    David     -- 0 -- Tied for first place
    Emily     -- 0 -- Tied for first place
    Fred      -- 0 -- Tied for first place
    Geraldine -- 0 -- Tied for first place
+   Hank      -- 0 -- Tied for first place
  There's still a seven-way tie for first.
 
 [Bloc STAR: Round 2: Scoring Round: Hashed Ballots tiebreaker]
@@ -146,41 +146,41 @@
  Counter is now 3
  3 shuffles
  Permuted list of candidates:
-   Brian
-   Emily
-   Amy
    Fred
-   David
+   Emily
    Geraldine
+   David
    Chuck
+   Brian
+   Amy
    Hank
  Choosing the earliest two of these candidates from the permuted list:
    Amy
-   Brian
    Chuck
    David
    Emily
    Fred
    Geraldine
- Selected winners: Brian and Emily
+   Hank
+ Selected winners: Fred and Emily
 
 [Bloc STAR: Round 2: Automatic Runoff Round]
  The candidate preferred in the most head-to-head matchups wins.
-   Brian         --  0 -- Tied for first place
    Emily         --  0 -- Tied for first place
+   Fred          --  0 -- Tied for first place
    No Preference -- 12
  There's a two-way tie for first.
 
 [Bloc STAR: Round 2: Automatic Runoff Round: First tiebreaker]
  The highest-scoring candidate wins.
-   Brian -- 36 -- Tied for first place
    Emily -- 36 -- Tied for first place
+   Fred  -- 36 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 2: Automatic Runoff Round: Second tiebreaker]
  The candidate with the most votes of score 5 wins.
-   Brian -- 0 -- Tied for first place
    Emily -- 0 -- Tied for first place
+   Fred  -- 0 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 2: Automatic Runoff Round: Hashed Ballots tiebreaker]
@@ -188,48 +188,48 @@
  Counter is now 4
  3 shuffles
  Permuted list of candidates:
-   Emily
-   Chuck
-   Geraldine
-   Hank
-   Fred
-   Brian
-   Amy
    David
- Choosing the earliest of these candidates from the permuted list:
-   Brian
    Emily
+   Hank
+   Chuck
+   Fred
+   Geraldine
+   Amy
+   Brian
+ Choosing the earliest of these candidates from the permuted list:
+   Emily
+   Fred
  Selected winner: Emily
 
 [Bloc STAR: Round 3: Scoring Round]
  The two highest-scoring candidates advance to the next round.
    Amy       -- 36 (average 3) -- Tied for first place
-   Brian     -- 36 (average 3) -- Tied for first place
    Chuck     -- 36 (average 3) -- Tied for first place
    David     -- 36 (average 3) -- Tied for first place
    Fred      -- 36 (average 3) -- Tied for first place
    Geraldine -- 36 (average 3) -- Tied for first place
+   Hank      -- 36 (average 3) -- Tied for first place
  There's a six-way tie for first.
 
 [Bloc STAR: Round 3: Scoring Round: First tiebreaker]
  The two candidates preferred in the most head-to-head matchups advance.
    Amy           --  0 -- Tied for first place
-   Brian         --  0 -- Tied for first place
    Chuck         --  0 -- Tied for first place
    David         --  0 -- Tied for first place
    Fred          --  0 -- Tied for first place
    Geraldine     --  0 -- Tied for first place
+   Hank          --  0 -- Tied for first place
    No Preference -- 12
  There's still a six-way tie for first.
 
 [Bloc STAR: Round 3: Scoring Round: Second tiebreaker]
  The two candidates with the most votes of score 5 advance.
    Amy       -- 0 -- Tied for first place
-   Brian     -- 0 -- Tied for first place
    Chuck     -- 0 -- Tied for first place
    David     -- 0 -- Tied for first place
    Fred      -- 0 -- Tied for first place
    Geraldine -- 0 -- Tied for first place
+   Hank      -- 0 -- Tied for first place
  There's still a six-way tie for first.
 
 [Bloc STAR: Round 3: Scoring Round: Hashed Ballots tiebreaker]
@@ -237,40 +237,40 @@
  Counter is now 5
  3 shuffles
  Permuted list of candidates:
-   Brian
    Amy
-   Hank
-   Geraldine
-   David
-   Emily
-   Chuck
    Fred
+   Brian
+   Chuck
+   Geraldine
+   Emily
+   David
+   Hank
  Choosing the earliest two of these candidates from the permuted list:
    Amy
-   Brian
    Chuck
    David
    Fred
    Geraldine
- Selected winners: Brian and Amy
+   Hank
+ Selected winners: Amy and Fred
 
 [Bloc STAR: Round 3: Automatic Runoff Round]
  The candidate preferred in the most head-to-head matchups wins.
    Amy           --  0 -- Tied for first place
-   Brian         --  0 -- Tied for first place
+   Fred          --  0 -- Tied for first place
    No Preference -- 12
  There's a two-way tie for first.
 
 [Bloc STAR: Round 3: Automatic Runoff Round: First tiebreaker]
  The highest-scoring candidate wins.
-   Amy   -- 36 -- Tied for first place
-   Brian -- 36 -- Tied for first place
+   Amy  -- 36 -- Tied for first place
+   Fred -- 36 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 3: Automatic Runoff Round: Second tiebreaker]
  The candidate with the most votes of score 5 wins.
-   Amy   -- 0 -- Tied for first place
-   Brian -- 0 -- Tied for first place
+   Amy  -- 0 -- Tied for first place
+   Fred -- 0 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 3: Automatic Runoff Round: Hashed Ballots tiebreaker]
@@ -278,45 +278,45 @@
  Counter is now 6
  3 shuffles
  Permuted list of candidates:
-   Hank
    Chuck
+   Emily
+   Amy
    Geraldine
    Brian
-   Emily
    David
+   Hank
    Fred
-   Amy
  Choosing the earliest of these candidates from the permuted list:
    Amy
-   Brian
- Selected winner: Brian
+   Fred
+ Selected winner: Amy
 
 [Bloc STAR: Round 4: Scoring Round]
  The two highest-scoring candidates advance to the next round.
-   Amy       -- 36 (average 3) -- Tied for first place
    Chuck     -- 36 (average 3) -- Tied for first place
    David     -- 36 (average 3) -- Tied for first place
    Fred      -- 36 (average 3) -- Tied for first place
    Geraldine -- 36 (average 3) -- Tied for first place
+   Hank      -- 36 (average 3) -- Tied for first place
  There's a five-way tie for first.
 
 [Bloc STAR: Round 4: Scoring Round: First tiebreaker]
  The two candidates preferred in the most head-to-head matchups advance.
-   Amy           --  0 -- Tied for first place
    Chuck         --  0 -- Tied for first place
    David         --  0 -- Tied for first place
    Fred          --  0 -- Tied for first place
    Geraldine     --  0 -- Tied for first place
+   Hank          --  0 -- Tied for first place
    No Preference -- 12
  There's still a five-way tie for first.
 
 [Bloc STAR: Round 4: Scoring Round: Second tiebreaker]
  The two candidates with the most votes of score 5 advance.
-   Amy       -- 0 -- Tied for first place
    Chuck     -- 0 -- Tied for first place
    David     -- 0 -- Tied for first place
    Fred      -- 0 -- Tied for first place
    Geraldine -- 0 -- Tied for first place
+   Hank      -- 0 -- Tied for first place
  There's still a five-way tie for first.
 
 [Bloc STAR: Round 4: Scoring Round: Hashed Ballots tiebreaker]
@@ -324,38 +324,38 @@
  Counter is now 7
  3 shuffles
  Permuted list of candidates:
-   Hank
-   Chuck
+   David
    Geraldine
-   Amy
    Emily
    Fred
+   Chuck
+   Hank
    Brian
-   David
- Choosing the earliest two of these candidates from the permuted list:
    Amy
+ Choosing the earliest two of these candidates from the permuted list:
    Chuck
    David
    Fred
    Geraldine
- Selected winners: Chuck and Geraldine
+   Hank
+ Selected winners: David and Geraldine
 
 [Bloc STAR: Round 4: Automatic Runoff Round]
  The candidate preferred in the most head-to-head matchups wins.
-   Chuck         --  0 -- Tied for first place
+   David         --  0 -- Tied for first place
    Geraldine     --  0 -- Tied for first place
    No Preference -- 12
  There's a two-way tie for first.
 
 [Bloc STAR: Round 4: Automatic Runoff Round: First tiebreaker]
  The highest-scoring candidate wins.
-   Chuck     -- 36 -- Tied for first place
+   David     -- 36 -- Tied for first place
    Geraldine -- 36 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 4: Automatic Runoff Round: Second tiebreaker]
  The candidate with the most votes of score 5 wins.
-   Chuck     -- 0 -- Tied for first place
+   David     -- 0 -- Tied for first place
    Geraldine -- 0 -- Tied for first place
  There's still a two-way tie for first.
 
@@ -364,42 +364,42 @@
  Counter is now 8
  3 shuffles
  Permuted list of candidates:
+   Chuck
+   Fred
    Emily
+   Geraldine
    Hank
    David
-   Fred
-   Geraldine
    Brian
    Amy
-   Chuck
  Choosing the earliest of these candidates from the permuted list:
-   Chuck
+   David
    Geraldine
  Selected winner: Geraldine
 
 [Bloc STAR: Round 5: Scoring Round]
  The two highest-scoring candidates advance to the next round.
-   Amy   -- 36 (average 3) -- Tied for first place
    Chuck -- 36 (average 3) -- Tied for first place
    David -- 36 (average 3) -- Tied for first place
    Fred  -- 36 (average 3) -- Tied for first place
+   Hank  -- 36 (average 3) -- Tied for first place
  There's a four-way tie for first.
 
 [Bloc STAR: Round 5: Scoring Round: First tiebreaker]
  The two candidates preferred in the most head-to-head matchups advance.
-   Amy           --  0 -- Tied for first place
    Chuck         --  0 -- Tied for first place
    David         --  0 -- Tied for first place
    Fred          --  0 -- Tied for first place
+   Hank          --  0 -- Tied for first place
    No Preference -- 12
  There's still a four-way tie for first.
 
 [Bloc STAR: Round 5: Scoring Round: Second tiebreaker]
  The two candidates with the most votes of score 5 advance.
-   Amy   -- 0 -- Tied for first place
    Chuck -- 0 -- Tied for first place
    David -- 0 -- Tied for first place
    Fred  -- 0 -- Tied for first place
+   Hank  -- 0 -- Tied for first place
  There's still a four-way tie for first.
 
 [Bloc STAR: Round 5: Scoring Round: Hashed Ballots tiebreaker]
@@ -408,37 +408,37 @@
  3 shuffles
  Permuted list of candidates:
    Emily
-   Fred
-   David
    Hank
+   Amy
    Chuck
    Brian
-   Amy
+   David
+   Fred
    Geraldine
  Choosing the earliest two of these candidates from the permuted list:
-   Amy
    Chuck
    David
    Fred
- Selected winners: Fred and David
+   Hank
+ Selected winners: Hank and Chuck
 
 [Bloc STAR: Round 5: Automatic Runoff Round]
  The candidate preferred in the most head-to-head matchups wins.
-   David         --  0 -- Tied for first place
-   Fred          --  0 -- Tied for first place
+   Chuck         --  0 -- Tied for first place
+   Hank          --  0 -- Tied for first place
    No Preference -- 12
  There's a two-way tie for first.
 
 [Bloc STAR: Round 5: Automatic Runoff Round: First tiebreaker]
  The highest-scoring candidate wins.
-   David -- 36 -- Tied for first place
-   Fred  -- 36 -- Tied for first place
+   Chuck -- 36 -- Tied for first place
+   Hank  -- 36 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 5: Automatic Runoff Round: Second tiebreaker]
  The candidate with the most votes of score 5 wins.
-   David -- 0 -- Tied for first place
-   Fred  -- 0 -- Tied for first place
+   Chuck -- 0 -- Tied for first place
+   Hank  -- 0 -- Tied for first place
  There's still a two-way tie for first.
 
 [Bloc STAR: Round 5: Automatic Runoff Round: Hashed Ballots tiebreaker]
@@ -446,22 +446,22 @@
  Counter is now 10
  3 shuffles
  Permuted list of candidates:
-   Fred
-   Hank
-   Emily
-   Amy
-   Geraldine
    Chuck
+   David
    Brian
-   David
- Choosing the earliest of these candidates from the permuted list:
-   David
    Fred
- Selected winner: Fred
+   Amy
+   Emily
+   Hank
+   Geraldine
+ Choosing the earliest of these candidates from the permuted list:
+   Chuck
+   Hank
+ Selected winner: Chuck
 
 [Bloc STAR: Winners]
- Hank
- Emily
  Brian
+ Emily
+ Amy
  Geraldine
- Fred
+ Chuck

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -556,16 +556,27 @@ class StarvoteTests(unittest.TestCase):
 
     def test_starvote_custom_serializer(self):
         for i in range(30):
-            self.assertEqual(starvote.starvote_custom_serializer(i), b'\x01int\x02' + str(i).encode('ascii') + b'\x03')
+            b = starvote.starvote_custom_serializer(i)
+            self.assertEqual(b, b'\x01int\x02' + str(i).encode('ascii') + b'\x03')
 
-        fake_ballot_list = [ [ ('Abel', 1), ('Jacob', 2) ],  [ ('Abel', 2), ('Jacob', 4) ], [ ('Abel', 3), ('Jacob', 5) ],  ]
-        self.assertEqual(starvote.starvote_custom_serializer(fake_ballot_list),
-            b'\x01ballots\x1f3\x02Abel\x1f1\x1eJacob\x1f2\x1dAbel\x1f2\x1eJacob\x1f4\x1dAbel\x1f3\x1eJacob\x1f5\x03')
+            i2 = starvote.starvote_custom_deserializer(b)
+            self.assertEqual(i, i2)
 
-        candidate_name_with_control_characters = [ [ ('\x01el', 1), ('Jacob', 2) ],  [ ('\x0ebel', 2), ('Jacob', 4) ], [ ('\x05bel', 3), ('\x1fJacob', 5) ],  ]
-        self.assertEqual(starvote.starvote_custom_serializer(candidate_name_with_control_characters),
-            b'\x01ballots\x1f3\x02\x1a\x01el\x1f1\x1eJacob\x1f2\x1d\x1a\x0ebel\x1f2\x1eJacob\x1f4\x1d\x1a\x05bel\x1f3\x1e\x1a\x1fJacob\x1f5\x03')
+        for ballots, serialized_form in (
+                (
+                    [ [ ('Abel', 1), ('Jacob', 2) ],  [ ('Abel', 2), ('Jacob', 4) ], [ ('Abel', 3), ('Jacob', 5) ], ],
+                    b'\x01ballots\x1f3\x02Abel\x1f1\x1eJacob\x1f2\x1dAbel\x1f2\x1eJacob\x1f4\x1dAbel\x1f3\x1eJacob\x1f5\x03',
+                ),
+                (
+                    [ [ ('\x01el', 1), ('Jacob', 2) ],  [ ('\x0ebel', 2), ('Jacob', 4) ], [ ('\x05bel', 3), ('\x1fJacob', 5) ], ],
+                    b'\x01ballots\x1f3\x02\x1a\x01el\x1f1\x1eJacob\x1f2\x1d\x1a\x0ebel\x1f2\x1eJacob\x1f4\x1d\x1a\x05bel\x1f3\x1e\x1a\x1fJacob\x1f5\x03',
+                ),
+            ):
+            b = starvote.starvote_custom_serializer(ballots)
+            self.assertEqual(b, serialized_form)
 
+            ballots2 =  starvote.starvote_custom_deserializer(b)
+            self.assertEqual(ballots, ballots2)
 
 
     def test_hand_starvote_format_seed_syntax(self):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -562,9 +562,9 @@ class StarvoteTests(unittest.TestCase):
         self.assertEqual(starvote.starvote_custom_serializer(fake_ballot_list),
             b'\x01ballots\x1f3\x02Abel\x1f1\x1eJacob\x1f2\x1dAbel\x1f2\x1eJacob\x1f4\x1dAbel\x1f3\x1eJacob\x1f5\x03')
 
-        invalid_candidate_name = [ [ ('\x0ebel', 1), ('Jacob', 2) ],  [ ('\x0ebel', 2), ('Jacob', 4) ], [ ('\x0ebel', 3), ('Jacob', 5) ],  ]
-        with self.assertRaises(ValueError):
-            starvote.starvote_custom_serializer(invalid_candidate_name)
+        candidate_name_with_control_characters = [ [ ('\x01el', 1), ('Jacob', 2) ],  [ ('\x0ebel', 2), ('Jacob', 4) ], [ ('\x05bel', 3), ('\x1fJacob', 5) ],  ]
+        self.assertEqual(starvote.starvote_custom_serializer(candidate_name_with_control_characters),
+            b'\x01ballots\x1f3\x02\x1a\x01el\x1f1\x1eJacob\x1f2\x1d\x1a\x0ebel\x1f2\x1eJacob\x1f4\x1d\x1a\x05bel\x1f3\x1e\x1a\x1fJacob\x1f5\x03')
 
 
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -148,6 +148,8 @@ tied_election = """
 
 class StarvoteTests(unittest.TestCase):
 
+    maxDiff = 2**32
+
     def test_import_star(self):
         # test that import * works
         # (it will fail if there's a bug with the definition of __all__)
@@ -550,6 +552,21 @@ class StarvoteTests(unittest.TestCase):
 """.lstrip()
         got = text_getvalue()
         self.assertEqual(got, expected_text)
+
+
+    def test_starvote_custom_serializer(self):
+        for i in range(30):
+            self.assertEqual(starvote.starvote_custom_serializer(i), b'\x01int\x02' + str(i).encode('ascii') + b'\x03')
+
+        fake_ballot_list = [ [ ('Abel', 1), ('Jacob', 2) ],  [ ('Abel', 2), ('Jacob', 4) ], [ ('Abel', 3), ('Jacob', 5) ],  ]
+        self.assertEqual(starvote.starvote_custom_serializer(fake_ballot_list),
+            b'\x01ballots\x1f3\x02Abel\x1f1\x1eJacob\x1f2\x1dAbel\x1f2\x1eJacob\x1f4\x1dAbel\x1f3\x1eJacob\x1f5\x03')
+
+        invalid_candidate_name = [ [ ('\x0ebel', 1), ('Jacob', 2) ],  [ ('\x0ebel', 2), ('Jacob', 4) ], [ ('\x0ebel', 3), ('Jacob', 5) ],  ]
+        with self.assertRaises(ValueError):
+            starvote.starvote_custom_serializer(invalid_candidate_name)
+
+
 
     def test_hand_starvote_format_seed_syntax(self):
         def test_raises(s, exception=SyntaxError):


### PR DESCRIPTION
Bugfix: the hashed_ballots_tiebreaker assumed
that marshal.dumps produced an identical bytes
string given identical inputs.  This is not true!
We also apparently can't rely on pickle.dumps
to be deterministic.  So, starvote now has
its own bespoke--and completely deterministic--simple binary serializer, called starvote_custom_serializer. It's tailor-made for the needs of starvote and
isn't useful for anybody else.  But it does guarantee that hashed_ballots_tiebreaker will now produce
identical results across all supported Python
versions, across all architectures, regardless of
optimization level.

Thanks to Petr Viktorin for the bug report!  Fixes #10.